### PR TITLE
Fix Queue.release() method

### DIFF
--- a/hustle.js
+++ b/hustle.js
@@ -589,11 +589,12 @@
                     }
 
                     var tube = item.tube;
+                    var activate
 
                     if (options.delay) {
                         var delay = parseInt(options.delay);
                         if (delay) {
-                            item.activate = new Date().getTime() + (1000 * delay);
+                            activate = new Date().getTime() + (1000 * delay);
                             tube = tbl.delayed;
                         }
                     }
@@ -605,7 +606,9 @@
                                 var pri = parseInt(options.priority);
                                 if (pri) item.priority = pri;
                             }
-                            delete item.tube;
+                            if (activate) {
+                                item.activate = activate
+                            }
                             return item;
                         },
                         success: options.success,

--- a/hustle.js
+++ b/hustle.js
@@ -848,9 +848,9 @@
                 // grab an item from the tube
                 reserve({
                     tube: tube,
-                    success: function(item) {
+                    success: async function(item) {
                         if (!item) return;
-                        fn(item);
+                        await fn(item);
                         // immediately poll for new items
                         setTimeout(function() {
                             poll({


### PR DESCRIPTION
The released items were never retrieved because the activate field was not properly set, and the item's tube was deleted